### PR TITLE
fix: drop support for python 3.13 to match specklia

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10" , "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10" , "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "DTCG API"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 keywords = [


### PR DESCRIPTION
``specklia`` depends on ``blosc``, which does not support Python 3.13.

Refs: #8