### PR TITLE
Add metadata updating to bindings

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,7 +52,7 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings
           # This ignores a bunch of linting errors
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics --ignore=E226,E231,E265,E501,W291,W293
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=80 --statistics --ignore=E226,E231,E265,E501,W291,W293,W503
       - name: Test with pytest and get coverage
         run: |
           coverage run --rcfile .coveragerc -m pytest && coverage report

--- a/dtcg/datacube/geozarr.py
+++ b/dtcg/datacube/geozarr.py
@@ -20,7 +20,6 @@ Functionality for exporting a GeoZarr file.
 
 from __future__ import annotations
 
-from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -185,5 +184,5 @@ class GeoZarrHandler(MetadataMapper):
             mode="w" if overwrite else "a",
             consolidated=True,
             zarr_format=self.zarr_format,
-            encoding=self.encoding,
+            encoding=self.encoding
         )

--- a/dtcg/datacube/geozarr.py
+++ b/dtcg/datacube/geozarr.py
@@ -188,7 +188,7 @@ class GeoZarrHandler(MetadataMapper):
     @property
     def dataset(self):
         """Load the written Zarr file as an xarray Dataset."""
-        return xr.open_zarr(self.memory_store)
+        return xr.open_zarr(self.memory_store, decode_cf=False)
 
     def export(self: GeoZarrHandler, storage_directory: str,
                overwrite: bool = True) -> None:

--- a/dtcg/integration/oggm_bindings.py
+++ b/dtcg/integration/oggm_bindings.py
@@ -30,6 +30,8 @@ import xarray as xr
 from oggm import cfg, tasks, utils, workflow
 from oggm.shop import its_live, w5e5
 import dtcg.datacube.cryotempo_eolis as cryotempo_eolis
+from dtcg.datacube.update_metadata import MetadataMapper
+from dtcg.datacube.geozarr import GeoZarrWriter
 import dtcg.integration.calibration
 
 # TODO: Link to DTCG instead.
@@ -847,6 +849,7 @@ class BindingsCryotempo(BindingsOggmWrangler):
         )
         self.datacube_manager = cryotempo_eolis.DatacubeCryotempoEolis()
         self.calibrator = dtcg.integration.calibration.CalibratorCryotempo()
+        self.metadata_mapper = MetadataMapper()
 
     def init_oggm(self, dirname="", **kwargs):
         return super().init_oggm(dirname, **kwargs)
@@ -878,6 +881,8 @@ class BindingsCryotempo(BindingsOggmWrangler):
         """Get gridded data enhanced with CryoTEMPO-EOLIS data."""
         with xr.open_dataset(gdir.get_filepath("gridded_data")) as datacube:
             datacube = datacube.load()
+
+        datacube = self.metadata_mapper.update_metadata(datacube)
 
         self.datacube_manager.retrieve_prepare_eolis_gridded_data(
             oggm_ds=datacube, grid=gdir.grid

--- a/dtcg/integration/oggm_bindings.py
+++ b/dtcg/integration/oggm_bindings.py
@@ -30,8 +30,7 @@ import xarray as xr
 from oggm import cfg, tasks, utils, workflow
 from oggm.shop import its_live, w5e5
 import dtcg.datacube.cryotempo_eolis as cryotempo_eolis
-from dtcg.datacube.update_metadata import MetadataMapper
-from dtcg.datacube.geozarr import GeoZarrWriter
+from dtcg.datacube.geozarr import GeoZarrHandler
 import dtcg.integration.calibration
 
 # TODO: Link to DTCG instead.
@@ -849,7 +848,6 @@ class BindingsCryotempo(BindingsOggmWrangler):
         )
         self.datacube_manager = cryotempo_eolis.DatacubeCryotempoEolis()
         self.calibrator = dtcg.integration.calibration.CalibratorCryotempo()
-        self.metadata_mapper = MetadataMapper()
 
     def init_oggm(self, dirname="", **kwargs):
         return super().init_oggm(dirname, **kwargs)
@@ -882,9 +880,10 @@ class BindingsCryotempo(BindingsOggmWrangler):
         with xr.open_dataset(gdir.get_filepath("gridded_data")) as datacube:
             datacube = datacube.load()
 
-        datacube = self.metadata_mapper.update_metadata(datacube)
-
         self.datacube_manager.retrieve_prepare_eolis_gridded_data(
             oggm_ds=datacube, grid=gdir.grid
         )
-        return gdir, datacube
+
+        geozarr_handler = GeoZarrHandler(datacube)
+
+        return gdir, geozarr_handler

--- a/dtcg/tests/datacube/test_geozarr.py
+++ b/dtcg/tests/datacube/test_geozarr.py
@@ -25,7 +25,7 @@ import xarray as xr
 import zarr
 import yaml
 
-from dtcg.datacube.geozarr import GeoZarrHandler, ZarrStorage
+from dtcg.datacube.geozarr import GeoZarrHandler
 
 
 class TestGeoZarrWriter:
@@ -68,28 +68,20 @@ class TestGeoZarrWriter:
         return ds, metadata_path
 
     @pytest.mark.filterwarnings("ignore:Metadata mapping is missing")
-    @pytest.mark.parametrize(
-        "storage_type", [ZarrStorage.memory_store, ZarrStorage.local_store]
-    )
-    def test_geozarr_attributes(self, tmp_path, test_dataset, storage_type):
+    def test_geozarr_attributes(self, tmp_path, test_dataset):
         """Test that spatial_ref, metadata, and dimensions are correct."""
         ds, metadata_path = test_dataset
 
-        store_dir = None
-        if storage_type == ZarrStorage.local_store:
-            store_dir = tmp_path / "geozarr_store"
+        store_dir = tmp_path / "geozarr_store"
 
         writer = GeoZarrHandler(
             ds=ds,
-            storage_type=storage_type,
-            storage_directory=store_dir,
-            overwrite=True,
             metadata_mapping_file_path=metadata_path,
         )
 
-        writer._write()
+        writer.export(store_dir)
 
-        root = zarr.open_group(store=writer.store, mode="r")
+        root = zarr.open_group(store=store_dir, mode="r")
 
         assert "spatial_ref" in root
         assert "crs_wkt" in root["spatial_ref"].attrs
@@ -112,28 +104,21 @@ class TestGeoZarrWriter:
         ds = ds.drop_dims("x")
 
         with pytest.raises(ValueError, match="Dataset must have at least dimensions"):
-            GeoZarrHandler(ds=ds, storage_type=ZarrStorage.memory_store)
-
-    def test_zarr_storage(self):
-        """Test ZarrStorage has appropriate attributes."""
-        for storage_type in ["memory_store", "local_store"]:
-            assert ZarrStorage(storage_type)
-            assert hasattr(ZarrStorage, storage_type)
+            GeoZarrHandler(ds=ds)
 
     @pytest.mark.filterwarnings("ignore:Metadata mapping is missing")
-    def test_correct_chunking(self, test_dataset):
+    def test_correct_chunking(self, test_dataset, tmp_path):
         """Test that chunking is computed as expected."""
         ds, _ = test_dataset
         writer = GeoZarrHandler(
             ds=ds,
-            storage_type=ZarrStorage.memory_store,
-            overwrite=True,
             target_chunk_mb=1,
         )
 
-        writer._write()
+        output_path = os.path.join(tmp_path, 'test_zarr.zarr')
+        writer.export(output_path)
 
-        root = zarr.open_group(store=writer.store, mode="r")
+        root = zarr.open_group(store=output_path, mode="r")
         temp_chunks = root["temperature"].chunks
         precip_chunks = root["precipitation"].chunks
 
@@ -150,12 +135,4 @@ class TestGeoZarrWriter:
         with pytest.raises(
             ValueError, match="Coordinate variable for dimension 't' is missing"
         ):
-            GeoZarrHandler(ds=ds, storage_type=ZarrStorage.memory_store)
-
-    def test_non_enum_storage_type(self, test_dataset):
-        # ensure correct error handling when incorrect storage type is supplied
-        ds, _ = test_dataset
-        with pytest.raises(NotImplementedError, match="Invalid storage_type."):
-            GeoZarrHandler(ds=ds, storage_type="blah")
-        with pytest.raises(ValueError, match="'blah' is not a valid ZarrStorage"):
-            ZarrStorage("blah")
+            GeoZarrHandler(ds=ds)


### PR DESCRIPTION
**GeoZarr**
- Renamed GeoZarrWriter → GeoZarrHandler to better reflect its broader role beyond just writing data.
- On initialisation, GeoZarrHandler now updates metadata immediately, meaning:
- The underlying xarray.Dataset is fully prepared and accessible via the ds class attribute.
- Example notebooks (e.g. [this one](https://github.com/DTC-Glaciers/dtcg-notebooks/blob/datacube-example/notebooks/04_calibrate_with_eolis_data.ipynb)) can load and use the handler directly without additional setup.
- Exporting to a file is simplified: handler.export().

**Bindings**
- BindingsCryotempo().get_eolis_data() now returns a GeoZarrHandler instance (instead of raw data), as shown in the notebook linked above.
- Other Bindings classes can adopt the same pattern where appropriate for consistency and usability.

**Linting**
Ignore W503 to follow modern PEP 8 (line breaks before binary operators). Without this, flake8 raises contradictory warnings depending on style (W503 vs W504), so disabling W503 resolves this conflict.