### PR TITLE
fix: remove direct reference and switch to pytest-mpl-oggm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ oggm = [
     "ipython",
     "joblib",
     "progressbar2",
-    "pytest-mpl @ git+https://github.com/OGGM/pytest-mpl",
+    "pytest-mpl-oggm",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
OGGM/pytest-mpl has changed URL to OGGM/pytest-mpl-oggm.